### PR TITLE
TableRow Changes and Additions

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/TableCell.java
+++ b/src/main/java/com/thoughtworks/gauge/TableCell.java
@@ -1,0 +1,31 @@
+package com.thoughtworks.gauge;
+
+/**
+ * This class represents a single table cell object containing
+ * the cell's value and it's associated column name.
+ */
+public class TableCell {
+    private String value;
+    private String columnName;
+
+    public TableCell(String cellValue, String columnName) {
+        value = cellValue;
+        this.columnName = columnName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "TableCell{" +
+                "value=" + value +
+                "columnName=" + columnName +
+                '}';
+    }
+}

--- a/src/main/java/com/thoughtworks/gauge/TableCell.java
+++ b/src/main/java/com/thoughtworks/gauge/TableCell.java
@@ -24,7 +24,7 @@ public class TableCell {
     @Override
     public String toString() {
         return "TableCell{" +
-                "value=" + value +
+                "value=" + value + ", " +
                 "columnName=" + columnName +
                 '}';
     }

--- a/src/main/java/com/thoughtworks/gauge/TableRow.java
+++ b/src/main/java/com/thoughtworks/gauge/TableRow.java
@@ -15,13 +15,13 @@
 
 package com.thoughtworks.gauge;
 
-import java.util.HashMap;
+import java.util.*;
 
 /**
  * Represents a Row of Data in a Table.
  */
 public class TableRow{
-    private HashMap<String, String> cells = new HashMap<String, String>();
+    private LinkedHashMap<String, String> cells = new LinkedHashMap<String, String>();
 
     /**
      * Get the value of cell corresponding to a column name.
@@ -57,5 +57,33 @@ public class TableRow{
         return "TableRow{" +
                 "cells=" + cells +
                 '}';
+    }
+
+    /**
+     * The method converts our table row to an array list.
+     * @return an array list containing the String cell values.
+     */
+    public List<String> getCellValues() {
+        //The LinkedHaspMap inherits the values() method, which returns a Collection view of
+        //    the values contained in the LinkedHaspMap
+        Collection<String> values = cells.values();
+
+        return new ArrayList<String>(values);
+    }
+
+    /**
+     * This method returns a list of cell objects that contain a value with its associated
+     * column name.
+     * @return listOfCells  a list containing our cell objects.
+     */
+    public List<TableCell> getTableCells() {
+        List<TableCell> listOfCells = new ArrayList<TableCell>();
+
+        for (Map.Entry<String, String> mapEntry : cells.entrySet()) {
+            TableCell cell = new TableCell(mapEntry.getValue(), mapEntry.getKey());
+            listOfCells.add(cell);
+        }
+
+        return listOfCells;
     }
 }


### PR DESCRIPTION
Changes and additions to the TableRow class and the addition of a
TableCell class to act as a subset of TableRow. 

The changes and additions to the TableRow class:
1. changed the data structure to LinkedHashMap
2. addition of getCellValues() method
3. addition of getTableCells() method.

TableCell class represents a single cell instance and contains the 
cell's value and column name.

These changes were implemented to provide ease of use and remove the need
to code the underlying implementation when working with individual cells.
The change in the data structure to a LinkedHashMap and the addition of the
getCellValues() method is to allow us to iterate through a table row more
easily.  In addition, the structure gaurantees the order, while not sorting
anything in a table row.

The getTableCells() method and the addition of the TableCell class (to act as
a subset of TableRow) was added to allow ease of use when we would like to access
individual cells, or work with individual cells, but don't want to code the 
underlying implementation.
